### PR TITLE
fix: Fixed the issues with diagnostics in `lualine`

### DIFF
--- a/lua/user/plugins/lualine.lua
+++ b/lua/user/plugins/lualine.lua
@@ -74,7 +74,7 @@ lualine.setup({
 		lualine_c = {
 			{
 				'diagnostics',
-				sources = { 'nvim_lsp', 'nvim_workspace_diagnostic', 'nvim_diagnostic' },
+				sources = { 'nvim_lsp' },
 				symbols = { error = ' ', warn = ' ', info = ' ' },
 				sections = { 'error', 'warn', 'info' },
 				colored = true,


### PR DESCRIPTION
The number of the diagnostics are shown more than it should be on the `lualine`.

Example. One error occurs and number of diagnostics shown is 3 on the `lualine`.