### PR TITLE
feat: Added the `ltex` language tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ luac.out
 *.x86_64
 *.hex
 
+# unrelated
+*note.md
 
 plugin/packer_compiled.lua
 .luarc.json

--- a/lua/user/core/autocmd.lua
+++ b/lua/user/core/autocmd.lua
@@ -34,3 +34,7 @@ vim.cmd([[
 -----------------------------------
 vim.cmd([[autocmd FileType lua :%s/\s\+$//e]])
 
+-----------------------------------
+-- auto reload ltex-extra plugin --
+-----------------------------------
+vim.cmd([[autocmd BufWritePost *.md,*gitcommit,*.org,*.txt,*.tex,*.bib lua require('ltex_extra').reload()]])

--- a/lua/user/plugins-setup.lua
+++ b/lua/user/plugins-setup.lua
@@ -109,6 +109,8 @@ return packer.startup(function(use)
 	use('dhruvasagar/vim-table-mode') -- markdown table
 	use('mzlogin/vim-markdown-toc') -- toc generator
 
+	use('barreiroleo/ltex-extra.nvim')
+
 	-- startup time
 	-- use('dstein64/vim-startuptime')
 

--- a/lua/user/plugins/lsp/null-ls.lua
+++ b/lua/user/plugins/lsp/null-ls.lua
@@ -18,7 +18,7 @@ local eslint = {
 --------------------
 -- cspell setting --
 --------------------
-local cspell_custom_file_path = vim.fn.findfile('~/.config/cspell/cspell.json')
+local cspell_custom_file_path = vim.fn.findfile('~/.config/langs/cspell.json')
 
 local cspell_config_file_path = function()
 	local custom_path = nil
@@ -37,13 +37,16 @@ local cspell_config_args = function()
 end
 
 local cspell = {
+	diagnostics_postprocess = function(diagnostic)
+		if diagnostic.severity == vim.diagnostic.severity.WARN then
+			diagnostic.severity = vim.diagnostic.severity.HINT
+		end
+	end,
 	config = {
 		create_config_file = true,
 		find_json = cspell_config_file_path,
 	},
 	filetypes = {
-		'markdown',
-		'text',
 		'lua',
 		'javascript',
 		'javascriptreact',
@@ -53,7 +56,9 @@ local cspell = {
 		'css',
 	},
 	disable_filetypes = {
+		'text',
 		'NvimTree',
+		'markdown',
 	},
 	extra_args = {
 		'--config',
@@ -61,21 +66,6 @@ local cspell = {
 		'--cache',
 		'--gitignore',
 		'--no-gitignore',
-		'--locale',
-		'en-US',
-		'--language-id',
-		'companies',
-		'softwareTerms',
-		'misc',
-		'typescript',
-		'node',
-		'html',
-		'python',
-		'css',
-		'bash',
-		'fonts',
-		'filetypes',
-		'npm',
 	},
 }
 

--- a/lua/user/plugins/lualine.lua
+++ b/lua/user/plugins/lualine.lua
@@ -74,9 +74,9 @@ lualine.setup({
 		lualine_c = {
 			{
 				'diagnostics',
-				sources = { 'nvim_lsp' },
-				symbols = { error = ' ', warn = ' ', info = ' ' },
-				sections = { 'error', 'warn', 'info' },
+				sources = { 'nvim_diagnostic' },
+				symbols = { error = ' ', warn = ' ', info = ' ', hint = 'ﴞ ' },
+				sections = { 'error', 'warn', 'info', 'hint' },
 				colored = true,
 				update_in_insert = true,
 				always_visible = false,

--- a/lua/user/plugins/nvim-tree.lua
+++ b/lua/user/plugins/nvim-tree.lua
@@ -32,6 +32,7 @@ nvimtree.setup({
 	filters = {
 		exclude = {
 			'.http',
+			'.md',
 		},
 	},
 


### PR DESCRIPTION
Installed the new plugin called `ltex-extra` to improve the usability of `ltex` lsp. Currently, `ltex` has a feature to create custom path for the dictionary. If the custom path is found, It will use the custom path. If custom path is not found, the cwd is taken and dictionary will be created within the root level. This can lead us to manage all dictionaries, and other ltex's related files in a single place.

Other minor changes:

1. Refactored the cspell in `null-ls`
2. Add the autocmd to reload ltex dictionary files on saving (or BufWritePost)
3. Changed the `ltex` and `null-ls`'s cspell diagnostics severity to HINT
4. Added the `.gitignore`