### PR TITLE
fix: Fixed the diagnostic issue on `lualine`

### DIFF
--- a/lua/user/plugins/lualine.lua
+++ b/lua/user/plugins/lualine.lua
@@ -74,7 +74,7 @@ lualine.setup({
 		lualine_c = {
 			{
 				'diagnostics',
-				sources = { 'nvim_diagnostic' },
+				sources = { 'nvim_diagnostic', 'nvim_lsp', 'nvim_workspace_diagnostic' },
 				symbols = { error = ' ', warn = ' ', info = ' ', hint = 'ﴞ ' },
 				sections = { 'error', 'warn', 'info', 'hint' },
 				colored = true,


### PR DESCRIPTION
Added the missing sources from `lualine`. These sources were removed due to the fact that some sources generate duplicate diagnostics.

Further observation will be taken on the sources of diagnostics in lualine.