### PR TITLE
fix: Fixed the typescript issue on diagnostic

### DIFF
--- a/lua/user/plugins/lsp/lspconfig.lua
+++ b/lua/user/plugins/lsp/lspconfig.lua
@@ -158,11 +158,6 @@ lspconfig['ltex'].setup(coq.lsp_ensure_capabilities({
 typescript.setup(coq.lsp_ensure_capabilities({
 	server = {
 		on_attach = on_attach,
-		init_options = {
-			preferences = {
-				disableSuggestions = true,
-			},
-		},
 		commands = {
 			OrganizeImports = {
 				organize_imports,


### PR DESCRIPTION
Removed the option from the typescript server to fix the issue that some diagnostic does not show up upon error.