### PR TITLE
Feat: Removed the `typescript.nvim` and disabled specific diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ brew install lazygit
 | Keymap        | Description                                      | Comment                  |
 | ------------- | ------------------------------------------------ | ------------------------ |
 | `<leader>fma` | Apply formatting                                 | -                        |
-| `<leader>fmf` | Rename files and update imports                  | Plugin: Typescript       |
-| `<leader>fmd` | Remove unused variables                          | Plugin: Typescript       |
-| `<leader>fmm` | Add missing imports                              | Plugin: Typescript       |
+| `<leader>fmo` | Remove unused imports                            | -                        |
 |               |                                                  |                          |
 | `alt+up`      | Move the current line upward                     | -                        |
 | `alt+down`    | Move the current line downward                   | -                        |

--- a/lua/user/core/keymaps.lua
+++ b/lua/user/core/keymaps.lua
@@ -53,11 +53,7 @@ keymap.set('n', '<leader>ll', '<s-v>/\\%V', noremap) -- Search the pattern/word 
 ----------------
 -- formatting general
 keymap.set('n', '<leader>fma', 'gggqG', noremap) -- apply formatting if any
--- formatting with typescript.nvim
-keymap.set('n', '<leader>fmr', ':TypescriptRenameFile<CR>') -- rename file and update imports
-keymap.set('n', '<leader>fmd', ':TypescriptRemoveUnused<CR>') -- remove unused variables
-keymap.set('n', '<leader>fmm', ':TypescriptAddMissingImports<CR>') -- add missing imports
-keymap.set('n', '<leader>fmo', ':OrganizeImports<CR>') -- Organize Import (Custom)
+keymap.set('n', '<leader>fmo', ':OrganizeImports<CR>') -- Organize Import (Custom: typescript)
 -- formatting move lines
 keymap.set('n', '<a-up>', ':move -2<CR>', noremap) -- move line upward
 keymap.set('n', '<a-down>', ':move +1<CR>', noremap) -- move line downward

--- a/lua/user/plugins-setup.lua
+++ b/lua/user/plugins-setup.lua
@@ -78,7 +78,6 @@ return packer.startup(function(use)
 	-- configuring lsp servers
 	use('neovim/nvim-lspconfig') -- easily configure language servers
 	use({ 'glepnir/lspsaga.nvim', branch = 'main' }) -- enhanced lsp uis
-	use('jose-elias-alvarez/typescript.nvim') -- additional functionality for typescript server (e.g. rename file & update imports)
 
 	-- formatting & linting
 	use('jose-elias-alvarez/null-ls.nvim') -- configure formatters & linters


### PR DESCRIPTION
Removed keymaps related to `typescript.nvim` as the plugin is removed, and replaced the `typescript.nvim` with `tsserver` from lspconfig.

Disabled the `CommonJS module` related diagnostics from `tsserver` as it is not necessary diagnostics to show in JavaScript file.