### PR TITLE
refactor: Refactored the diagnostics

### DIFF
--- a/lua/user/plugins/lsp/lspconfig.lua
+++ b/lua/user/plugins/lsp/lspconfig.lua
@@ -101,7 +101,7 @@ local on_attach_ltex_extra = function(client, bufnr)
 end
 
 -- Change the Diagnostic symbols in the sign column (gutter)
-local signs = { Error = ' ', Warn = ' ', Hint = 'ﴞ ', Info = ' ' }
+local signs = { Error = ' ', Warn = ' ', Info = ' ' }
 for type, icon in pairs(signs) do
 	local hl = 'DiagnosticSign' .. type
 	vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = '' })

--- a/lua/user/plugins/lsp/null-ls.lua
+++ b/lua/user/plugins/lsp/null-ls.lua
@@ -39,7 +39,7 @@ end
 local cspell = {
 	diagnostics_postprocess = function(diagnostic)
 		if diagnostic.severity == vim.diagnostic.severity.WARN then
-			diagnostic.severity = vim.diagnostic.severity.HINT
+			diagnostic.severity = vim.diagnostic.severity.INFO
 		end
 	end,
 	config = {

--- a/lua/user/plugins/lualine.lua
+++ b/lua/user/plugins/lualine.lua
@@ -74,9 +74,9 @@ lualine.setup({
 		lualine_c = {
 			{
 				'diagnostics',
-				sources = { 'nvim_diagnostic', 'nvim_lsp', 'nvim_workspace_diagnostic' },
-				symbols = { error = ' ', warn = ' ', info = ' ', hint = 'ﴞ ' },
-				sections = { 'error', 'warn', 'info', 'hint' },
+				sources = { 'nvim_workspace_diagnostic' },
+				symbols = { error = ' ', warn = ' ', info = ' ' },
+				sections = { 'error', 'warn', 'info'},
 				colored = true,
 				update_in_insert = true,
 				always_visible = false,


### PR DESCRIPTION
Removed the duplication sources from `lualine`, and removed the sign and section of `hint` from `lualine`, `null-ls`, and `lspconfig`.