### PR TITLE
fix: Fixed the `lspsaga`'s unknown error

### DIFF
--- a/lua/user/plugins/lspconfig.lua
+++ b/lua/user/plugins/lspconfig.lua
@@ -44,7 +44,7 @@ return {
 			keymap.set('n', 'gi', '<cmd>lua vim.lsp.buf.implementation()<CR>', opts) -- go to implementation
 			keymap.set('n', '<leader>ca', '<cmd>Lspsaga code_action<CR>', opts) -- see available code actions
 			keymap.set('n', '<leader>rn', '<cmd>Lspsaga rename<CR>', opts) -- smart rename
-			keymap.set('n', '<leader>d', '<cmd>Lspsaga show_line_diagnostics<CR>', opts) -- show  diagnostics for line
+			-- keymap.set('n', '<leader>d', '<cmd>Lspsaga show_line_diagnostics<CR>', opts) -- show  diagnostics for line
 			keymap.set('n', '<leader>d', '<cmd>Lspsaga show_cursor_diagnostics<CR>', opts) -- show diagnostics for cursor
 			keymap.set('n', '[d', '<cmd>Lspsaga diagnostic_jump_prev<CR>', opts) -- jump to previous diagnostic in buffer
 			keymap.set('n', ']d', '<cmd>Lspsaga diagnostic_jump_next<CR>', opts) -- jump to next diagnostic in buffer

--- a/lua/user/plugins/lspsaga.lua
+++ b/lua/user/plugins/lspsaga.lua
@@ -11,15 +11,6 @@ return {
 			definition_action_keys = {
 				edit = '<CR>',
 			},
-			symbol_in_winbar = {
-				enable = true,
-				separator = ' ',
-				hide_keyword = true,
-				show_file = true,
-				folder_level = 2,
-				respect_root = true,
-				color_mode = true,
-			},
 			ui = {
 				-- currently only round theme
 				theme = 'round',


### PR DESCRIPTION
After new update, lspsaga continuously causes the unknown error and that seems caused by enabling SymbolWinbar manually. Removing setting from the config of lspsaga fixed the issue.