### PR TITLE
feat: add new plugin

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -14,6 +14,15 @@ vim.opt.rtp:prepend(lazypath)
 vim.g.maplocalleader = ' '
 vim.g.mapleader = ' '
 
+---------------------
+-- hardtime config --
+---------------------
+-- vim.g.hardtime_default_on = 1
+vim.g.hardtime_showmsg = 1
+vim.g.hardtime_timeout = 1200
+vim.g.hardtime_allow_different_key = 1
+vim.g.hardtime_motion_with_count_resets = 1
+---------------------
 require('user.core.options')
 require('user.core.keymaps')
 require('user.core.autocmd')

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -34,6 +34,7 @@
   "toggleterm.nvim": { "branch": "main", "commit": "2a787c426ef00cb3488c11b14f5dcf892bbd0bda" },
   "tokyonight.nvim": { "branch": "main", "commit": "6705d069d9b37146024113c36aa90cec90630859" },
   "typescript.nvim": { "branch": "main", "commit": "f66d4472606cb24615dfb7dbc6557e779d177624" },
+  "vim-hardtime": { "branch": "master", "commit": "91177392e9372a1cf09a4b9b79532d2490bd405f" },
   "vim-markdown-toc": { "branch": "master", "commit": "7ec05df27b4922830ace2246de36ac7e53bea1db" },
   "vim-matchup": { "branch": "master", "commit": "959e0e79ea240cdee29efbdd0d2e2e718931ccec" },
   "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" },

--- a/lua/user/core/keymaps.lua
+++ b/lua/user/core/keymaps.lua
@@ -3,6 +3,8 @@ local noremap = { noremap = true, silent = true }
 
 -- set leader key to space
 keymap.set('', '<Space>', '<Nop>', noremap)
+-- disable default help key
+keymap.set('', '<F1>', '<Nop>', noremap)
 vim.g.maplocalleader = ' '
 vim.g.mapleader = ' '
 

--- a/lua/user/plugins/init.lua
+++ b/lua/user/plugins/init.lua
@@ -46,6 +46,6 @@ return {
 		lazy = true,
 		ft = { 'markdown' },
 	}, -- toc generator
-
-	{ 'barreiroleo/ltex-extra.nvim', lazy = true },
+	{ 'barreiroleo/ltex-extra.nvim', lazy = true }, -- ltex
+	{ 'takac/vim-hardtime' }, -- hardtime
 }


### PR DESCRIPTION
add `vim-hardtime` plugin to enable hardtime mode. The hardtime mode enables the limitation of using some keys, such as arrow keys. The configs are also added to `init.lua`, and the `hardtime_default_on` is commented in default.

Core changes:
- feat: add `vim-hardtime` plugin
- feat: add configs of `vim-hardtime`

Misc Changes:
- feat: disable the `F1` keys to open the help buffer.