### PR TITLE
feat: add `autocmd` to clear the search on BufUnload

### DIFF
--- a/lua/user/core/autocmd.lua
+++ b/lua/user/core/autocmd.lua
@@ -50,3 +50,8 @@ vim.cmd([[
 		  \,sm:block-blinkwait175-blinkoff150-blinkon175
   augroup end
 ]])
+
+----------------------------------
+-- clear search when unload Buf --
+----------------------------------
+vim.cmd([[autocmd BufUnload * :let @/ = ""]])


### PR DESCRIPTION
The search function created in the previous commit is continuously shown on the `lualine`. To improve the user's experience, the last search register is cleared with an `autocmd` on BufUnload.