### PR TITLE
feat: disable the lightbulb from `lspsaga`

### DIFF
--- a/lua/user/plugins/lspsaga.lua
+++ b/lua/user/plugins/lspsaga.lua
@@ -7,6 +7,9 @@ return {
 	config = function()
 		local saga = require('lspsaga')
 		saga.setup({
+			lightbulb = {
+				enable = false,
+			},
 			diagnostic = {
 				on_insert = false,
 				on_insert_follow = false,


### PR DESCRIPTION
The lightbulb is an option in `lspsaga` that displays a lightbulb icon where `codeaction` is possible. However, this feature can be distracting while writing, so the option has been set to `false`.