### PR TITLE
feat: Replace typescript.nvim Keymaps with typescript.tool

### DIFF
--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -71,15 +71,16 @@ keymap.set('n', 'N', 'Nzz', noremap) -- center search result
 ----------------
 -- formatting general
 keymap.set('n', '<leader>fa', 'gggqG', noremap) -- apply formatting if any
-keymap.set('n', '<leader>fr', '<cmd>TypescriptRenameFile<CR>', noremap) -- rename file and update imports
-keymap.set('n', '<leader>fd', '<cmd>TypescriptRemoveUnused<CR>', noremap) -- remove unused variables
-keymap.set('n', '<leader>fm', '<cmd>TypescriptAddMissingImports<CR>', noremap) -- add missing imports
-keymap.set('n', '<leader>fi', '<cmd>OrganizeImports<CR>', noremap) -- Organize Import (Custom: typescript)
 -- formatting move lines
 keymap.set('n', '<a-up>', ':move -2<CR>', noremap) -- move line upward
 keymap.set('n', '<a-down>', ':move +1<CR>', noremap) -- move line downward
 -- formatting color
 keymap.set('n', '<leader>hio', ':so $VIMRUNTIME/syntax/hitest.vim<CR>', noremap) -- vim highlight group
+-- typescript
+-- More Info: https://github.com/pmizio/typescript-tools.nvim/blob/master/lua/typescript-tools/user_commands.lua
+keymap.set('n', '<leader>fd', '<cmd>TSToolsRemoveUnusedImports<CR>', noremap) -- remove unused variables
+keymap.set('n', '<leader>fs', '<cmd>TSToolsSortImports<CR>', noremap) -- sort and combine imports
+keymap.set('n', '<leader>fo', '<cmd>TSToolsOrganizeImports<CR>', noremap) -- Organize Import (Custom: typescript)
 
 -- navigation --
 -- general navigation


### PR DESCRIPTION
The typescript.nvim command keymaps have been replaced by typescript.tool keymaps, streamlining and updating the keymap set. It’s worth noting that the plugin currently lacks support for the command responsible for adding missing imports, which is compatible with typescript.tool.