### PR TITLE
refactor: Refine suppressing diagnostics message condition

### DIFF
--- a/lua/user/plugins/lspconfig.lua
+++ b/lua/user/plugins/lspconfig.lua
@@ -47,7 +47,7 @@ return {
 		vim.lsp.handlers['textDocument/publishDiagnostics'] = function(_, result, ctx, ...)
 			local client = vim.lsp.get_client_by_id(ctx.client_id)
 
-			if client and client.name == 'tsserver' then
+			if client and client.name == 'typescript-tools' then
 				result.diagnostics = vim.tbl_filter(function(diagnostic)
 					return not diagnostic.message:find('File is a CommonJS module; it may be converted to an ES module.')
 				end, result.diagnostics)


### PR DESCRIPTION
Update the condition for typescript-tools instead of tsserver to suppress the message. Enhancing the accuracy and relevance of diagnostics reporting.