### PR TITLE
refactor: Update the options of flash.nvim

### DIFF
--- a/lua/user/plugins/flash.lua
+++ b/lua/user/plugins/flash.lua
@@ -2,31 +2,5 @@ return {
 	'folke/flash.nvim',
 	event = 'VeryLazy',
 	opts = {},
-	keys = {
-		{
-			's',
-			mode = { 'n', 'x', 'o' },
-			function()
-				-- default options: exact mode, multi window, all directions, with a backdrop
-				require('flash').jump()
-			end,
-			desc = 'Flash',
-		},
-		{
-			'S',
-			mode = { 'n', 'o', 'x' },
-			function()
-				require('flash').treesitter()
-			end,
-			desc = 'Flash Treesitter',
-		},
-		{
-			'r',
-			mode = 'o',
-			function()
-				require('flash').remote()
-			end,
-			desc = 'Remote Flash',
-		},
-	},
+	keys = {},
 }


### PR DESCRIPTION
Remove the key options on the flash.nvim as search function can replace the key options.