### PR TITLE
feat: Revert to Typescript.nvim for diagnostic integration

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -39,7 +39,7 @@
   "telescope.nvim": { "branch": "0.1.x", "commit": "776b509f80dd49d8205b9b0d94485568236d1192" },
   "todo-comments.nvim": { "branch": "main", "commit": "09b0b17d824d2d56f02ff15967e8a2499a89c731" },
   "toggleterm.nvim": { "branch": "main", "commit": "95204ece0f2a54c89c4395295432f9aeedca7b5f" },
-  "typescript-tools.nvim": { "branch": "master", "commit": "9e6e50212e6a694e349523188686cdca96f8e93e" },
+  "typescript.nvim": { "branch": "main", "commit": "5b3680e5c386e8778c081173ea0c978c14a40ccb" },
   "vim-markdown-toc": { "branch": "master", "commit": "7ec05df27b4922830ace2246de36ac7e53bea1db" },
   "vim-matchup": { "branch": "master", "commit": "3a17944bfa3942da805a381750a1be4b314c64d2" },
   "vim-surround": { "branch": "master", "commit": "3d188ed2113431cf8dac77be61b842acb64433d9" },

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -74,9 +74,10 @@ keymap.set('n', '<a-down>', ':move +1<CR>', noremap) -- move line downward
 keymap.set('n', '<leader>hio', ':so $VIMRUNTIME/syntax/hitest.vim<CR>', noremap) -- vim highlight group
 -- typescript
 -- More Info: https://github.com/pmizio/typescript-tools.nvim/blob/master/lua/typescript-tools/user_commands.lua
-keymap.set('n', '<leader>fd', '<cmd>TSToolsRemoveUnusedImports<CR>', noremap) -- remove unused variables
-keymap.set('n', '<leader>fs', '<cmd>TSToolsSortImports<CR>', noremap) -- sort and combine imports
-keymap.set('n', '<leader>fo', '<cmd>TSToolsOrganizeImports<CR>', noremap) -- Organize Import (Custom: typescript)
+keymap.set('n', '<leader>fr', '<cmd>TypescriptRenameFile<CR>', noremap) -- rename file and update imports                                   █│
+keymap.set('n', '<leader>fd', '<cmd>TypescriptRemoveUnused<CR>', noremap) -- remove unused variables                                        █│
+keymap.set('n', '<leader>fm', '<cmd>TypescriptAddMissingImports<CR>', noremap) -- add missing imports                                       █│
+keymap.set('n', '<leader>fo', '<cmd>OrganizeImports<CR>', noremap) -- Organize Import (Custom: typescript)
 
 -- navigation --
 -- general navigation

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -10,11 +10,11 @@ return {
 	event = 'BufReadPre',
 	dependencies = {
 		'hrsh7th/cmp-nvim-lsp',
-		'pmizio/typescript-tools.nvim',
+		'jose-elias-alvarez/typescript.nvim',
 	},
 	config = function()
 		local lspconfig = require('lspconfig')
-		local typescript = require('typescript-tools')
+		local typescript = require('typescript')
 		local cmp_nvim_lsp = require('cmp_nvim_lsp')
 		---------------------
 		-- keymap setting ---


### PR DESCRIPTION
Reverting to Typescript.nvim from Typescript-tool.nvim due to the latter's lack of diagnostic integration. Typescript-tool.nvim has been observed to cause unresponsiveness or significantly slow responses in diagnostics.

Note: Once Typescript-tool integrates with global diagnostics it will be a great idea to test again.