### PR TITLE
feat: Implement keymap for word search under cursor

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -58,8 +58,9 @@ keymap.set('n', '<leader>qq', ':q<CR>', noremap) -- quit
 keymap.set('n', '<leader>ss', ':silent w<CR>', noremap) -- save
 keymap.set('n', '<leader>ee', ':e<CR>', noremap) -- save
 keymap.set('n', '<leader>EE', ':e!<CR>', noremap) -- save
--- search and  Replace
+-- search and Replace
 keymap.set('n', '<leader>RR', ':%s/<c-r><c-w>/<c-r><c-w>', noremap) -- Search and replace the word under current
+keymap.set('n', '<leader>rr', ':let @/ = "\\\\<" . expand(\'<cword>\') . "\\\\>"<CR>:set hlsearch<CR>', noremap) -- Search for the word under the cursor. cgn is removed for versatile usage.
 keymap.set('n', '<leader>ll', '<s-v>/\\%V', noremap) -- Search the pattern/word within the highlighted line
 keymap.set('n', 'n', 'nzz', noremap) -- center search result
 keymap.set('n', 'N', 'Nzz', noremap) -- center search result


### PR DESCRIPTION
Reinstate the previously omitted keymap for searching and replacing words under the cursor, ensuring compatibility with flash.nvim.

The new keymap implementation retains the original `<leader>rr` binding to search for words under the cursor. Recursive removal functionality via `cgn` is deliberately excluded to streamline keymapping usage, as the same can be triggered by directly typing `cgn`. The updated keymap promotes efficient interaction with the word search feature.