### PR TITLE
fix: Fix the commonJS diagnostic message

### DIFF
--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -47,7 +47,7 @@ return {
 		vim.lsp.handlers['textDocument/publishDiagnostics'] = function(_, result, ctx, ...)
 			local client = vim.lsp.get_client_by_id(ctx.client_id)
 
-			if client and client.name == 'typescript-tools' then
+			if client and client.name == 'tsserver' then
 				result.diagnostics = vim.tbl_filter(function(diagnostic)
 					return not diagnostic.message:find('File is a CommonJS module; it may be converted to an ES module.')
 				end, result.diagnostics)


### PR DESCRIPTION
Switch the condition to `tsserver` that was previously set to `typescript-tools`.