### PR TITLE
feat: Add keymap to disable search highlight

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -70,6 +70,8 @@ keymap.set('n', '<a-up>', ':move -2<CR>', noremap) -- move line upward
 keymap.set('n', '<a-down>', ':move +1<CR>', noremap) -- move line downward
 -- formatting color
 keymap.set('n', '<leader>hio', ':so $VIMRUNTIME/syntax/hitest.vim<CR>', noremap) -- vim highlight group
+-- formatting search
+keymap.set('n', '<ESC>', ':noh<CR>', noremap) -- exit search highlight
 
 -- typescript
 -- More Info: https://github.com/pmizio/typescript-tools.nvim/blob/master/lua/typescript-tools/user_commands.lua


### PR DESCRIPTION
Incorporate a new keymap that disables the search highlight once a search operation concludes. This enhancement ensures visibility of all search results within the viewport, but also allows for swift deactivation of highlighting, which can be distracting. Pressing the ESC key will now effectively disable the current search highlighting.