### PR TITLE
refactor: Migrate Neotree keymaps

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -133,12 +133,6 @@ keymap.set('n', '<leader>=', '<C-W>=', noremap) -- reset resize: press < alt-= >
 --  Plugin Keybinds --
 ----------------------
 
-------------------------------
--- file explorer Neotree ---
-------------------------------
-keymap.set('n', '<leader>eo', ':Neotree toggle<CR>', noremap) -- toggle file explorer
-keymap.set('n', '<leader>ef', ':Neotree reveal_force_cwd<CR>', noremap)
-
 ------------------------
 -- lsp server restart --
 ------------------------

--- a/lua/plugins/neo-tree.lua
+++ b/lua/plugins/neo-tree.lua
@@ -1,11 +1,16 @@
 -- more info:
 -- https://github.com/nvim-neo-tree/neo-tree.nvim
+local noremap = { noremap = true, silent = true }
 
 return {
 	'nvim-neo-tree/neo-tree.nvim',
 	branch = 'v2.x',
 	dependencies = {
 		'MunifTanjim/nui.nvim',
+	},
+	keys = {
+		{ '<leader>eo', ':Neotree toggle<CR>', noremap }, -- toggle file explorer
+		{ '<leader>ef', ':Neotree reveal_force_cwd<CR>', noremap }, -- reveal in file explorer with forced current working directory
 	},
 	config = function()
 		require('neo-tree').setup({


### PR DESCRIPTION
Relocate keymaps associated with the Neotree plugin to the `Neotree` plugin file from the `keymaps` file. Enhances maintainability and organization.