### PR TITLE
feat: Relocate Lspconfig keymaps

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -133,15 +133,6 @@ keymap.set('n', '<leader>=', '<C-W>=', noremap) -- reset resize: press < alt-= >
 --  Plugin Keybinds --
 ----------------------
 
-------------------------
--- lsp server restart --
-------------------------
-keymap.set('n', '<leader>lr', ':LspRestart<CR>', noremap) -- mapping to restart lsp if necessary
-keymap.set('n', '<leader>ld', ':lua vim.diagnostic.reset()<CR>', noremap) -- reset diagnostics
-keymap.set('n', '<leader>ls', ':LspStart<CR>', noremap) -- start lsp
-keymap.set('n', '<leader>lx', ':LspStop<CR>', noremap) -- stop lsp
-keymap.set('n', '<leader>li', ':LspInfo<CR>', noremap) -- lsp info
-
 -- markdown preview
 keymap.set('n', '<leader>mpo', ':MarkdownPreview<CR>', noremap) -- start markdown preview open
 keymap.set('n', '<leader>mps', ':MarkdownPreviewStop<CR>', noremap) -- stop markdown preview stop

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -1,4 +1,6 @@
 -- https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md
+local noremap = { noremap = true, silent = true }
+
 vim.diagnostic.config({
 	underline = true,
 	virtual_text = false,
@@ -11,6 +13,13 @@ return {
 	dependencies = {
 		'hrsh7th/cmp-nvim-lsp',
 		'jose-elias-alvarez/typescript.nvim',
+	},
+	keys = {
+		{ '<leader>lr', ':LspRestart<CR>', noremap }, -- mapping to restart lsp if necessary
+		{ '<leader>ld', ':lua vim.diagnostic.reset()<CR>', noremap }, -- reset diagnostics
+		{ '<leader>ls', ':LspStart<CR>', noremap }, -- start lsp
+		{ '<leader>lx', ':LspStop<CR>', noremap }, -- stop lsp
+		{ '<leader>li', ':LspInfo<CR>', noremap }, -- lsp info
 	},
 	config = function()
 		local lspconfig = require('lspconfig')


### PR DESCRIPTION
Move the Lspconfig keymaps to the `lspconfig` file from the `keymaps` file to streamline the configuration structure.