### PR TITLE
refactor: Relocate Markdown-preview plugin and keymaps

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -1,5 +1,6 @@
 local keymap = vim.keymap -- for conciseness
 local noremap = { noremap = true, silent = true }
+
 -- set leader key to space
 keymap.set('', '<Space>', '<Nop>', noremap)
 -- disable default help key
@@ -132,10 +133,6 @@ keymap.set('n', '<leader>=', '<C-W>=', noremap) -- reset resize: press < alt-= >
 ----------------------
 --  Plugin Keybinds --
 ----------------------
-
--- markdown preview
-keymap.set('n', '<leader>mpo', ':MarkdownPreview<CR>', noremap) -- start markdown preview open
-keymap.set('n', '<leader>mps', ':MarkdownPreviewStop<CR>', noremap) -- stop markdown preview stop
 
 -- markdown toc
 keymap.set('n', '<leader>mco', ':GenTocGFM<CR>', noremap) -- generate markdown toc

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -26,28 +26,6 @@ return {
 	-- vscode like icon
 	'nvim-tree/nvim-web-devicons',
 
-	-- markdown
-	{
-		'iamcco/markdown-preview.nvim',
-		build = 'cd app && npm install',
-		lazy = true,
-		config = function()
-			local browser_path = '/Applications/Firefox.app'
-			-- comment browser_path if you want to use the default browser
-			local check_browser_path = vim.fn.findfile(browser_path)
-			local custom_browser_path = function()
-				local custom_path = nil
-				if check_browser_path ~= nil then
-					custom_path = browser_path
-				end
-				return custom_path
-			end
-
-			vim.g.mkdp_filetypes = { 'markdown' }
-			vim.g.mkdp_browser = custom_browser_path()
-		end,
-		ft = { 'markdown' },
-	}, -- markdown preview
 	{
 		'dhruvasagar/vim-table-mode',
 		lazy = true,

--- a/lua/plugins/markdown-preview.lua
+++ b/lua/plugins/markdown-preview.lua
@@ -1,0 +1,27 @@
+local noremap = { noremap = true, silent = true }
+
+return {
+	'iamcco/markdown-preview.nvim',
+	build = 'cd app && npm install',
+	lazy = true,
+	keys = {
+		{ '<leader>mpo', ':MarkdownPreview<CR>', noremap }, -- start markdown preview open
+		{ '<leader>mps', ':MarkdownPreviewStop<CR>', noremap }, -- stop markdown preview stop
+	},
+	config = function()
+		local browser_path = '/Applications/Firefox.app'
+		-- comment browser_path if you want to use the default browser
+		local check_browser_path = vim.fn.findfile(browser_path)
+		local custom_browser_path = function()
+			local custom_path = nil
+			if check_browser_path ~= nil then
+				custom_path = browser_path
+			end
+			return custom_path
+		end
+
+		vim.g.mkdp_filetypes = { 'markdown' }
+		vim.g.mkdp_browser = custom_browser_path()
+	end,
+	ft = { 'markdown' },
+}


### PR DESCRIPTION
Move Markdown-preview plugin to a dedicated plugin file and reposition its associated keymaps within the same file. Enhance structure and cohesiveness by keeping the plugin and its keymaps together.