### PR TITLE
refactor: Consolidate plugins and keymaps into dedicated files

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -134,11 +134,6 @@ keymap.set('n', '<leader>=', '<C-W>=', noremap) -- reset resize: press < alt-= >
 --  Plugin Keybinds --
 ----------------------
 
--- markdown toc
-keymap.set('n', '<leader>mco', ':GenTocGFM<CR>', noremap) -- generate markdown toc
-keymap.set('n', '<leader>mcu', ':UpdateToc<CR>', noremap) -- update markdown toc
-keymap.set('n', '<leader>mcd', ':RemoveToc<CR>', noremap) -- delete markdown toc
-
 -- colorizer
 keymap.set('n', '<leader>cro', ':ColorizerToggle<CR>', noremap) -- toggle colorizer
 

--- a/lua/plugins/harpoon.lua
+++ b/lua/plugins/harpoon.lua
@@ -1,0 +1,16 @@
+-- https://github.com/ThePrimeagen/harpoon
+
+local noremap = { noremap = true, silent = true }
+
+return {
+	'ThePrimeagen/harpoon',
+	lazy = true,
+	keys = {
+		{ '<leader>ha', ':lua require("harpoon.mark").add_file()<CR>', noremap }, -- add file
+		{ '<leader>hd', ':lua require("harpoon.mark").rm_file()<CR>', noremap }, -- remove file
+		{ '<leader>hc', ':lua require("harpoon.mark").clear_all()<CR>', noremap }, -- clear all files
+		{ '<leader>hq', ':lua require("harpoon.ui").toggle_quick_menu()<CR>', noremap }, -- quick menu
+		{ '<leader>o', ':lua require("harpoon.ui").nav_next()<CR>zz', noremap }, -- navigate to next mark
+		{ '<leader>i', ':lua require("harpoon.ui").nav_prev()<CR>zz', noremap }, -- navigate to previous mark
+	},
+}

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -1,20 +1,12 @@
 -- https://github.com/folke/lazy.nvim
+
 return {
-	-- plugin manager
 	'nvim-lua/plenary.nvim', -- lua functions that many plugins use
-
-	-- colors
-	'norcalli/nvim-colorizer.lua', -- colorizer
-
-	-- essential plugins
 	'tpope/vim-surround', -- add, delete, change surroundings (it's awesome)
 	'vim-scripts/ReplaceWithRegister', -- replace with register contents using motion (gr + motion)
-
-	-- commenting
-	{ 'numToStr/Comment.nvim' },
-	{ 'JoosepAlviste/nvim-ts-context-commentstring' },
-
-	-- search and finder
+	'numToStr/Comment.nvim',
+	'JoosepAlviste/nvim-ts-context-commentstring',
+	'nvim-tree/nvim-web-devicons',
 	{
 		'andymass/vim-matchup',
 		lazy = true,
@@ -22,15 +14,6 @@ return {
 			vim.g.matchup_matchparen_offscreen = ''
 		end,
 	},
-
-	-- vscode like icon
-	'nvim-tree/nvim-web-devicons',
-
-	{
-		'mzlogin/vim-markdown-toc',
-		lazy = true,
-		ft = { 'markdown' },
-	}, -- toc generator
 	{
 		'utilyre/barbecue.nvim',
 		name = 'barbecue',
@@ -61,8 +44,5 @@ return {
 				auto_session_suppress_dirs = { '~/', '~/Projects', '~/Downloads', '/' },
 			})
 		end,
-	},
-	{
-		'ThePrimeagen/harpoon',
 	},
 }

--- a/lua/plugins/nvim-colorizer.lua
+++ b/lua/plugins/nvim-colorizer.lua
@@ -1,0 +1,11 @@
+-- https://github.com/norcalli/nvim-colorizer.lua
+
+local noremap = { noremap = true, silent = true }
+
+return {
+	'norcalli/nvim-colorizer.lua',
+	lazy = true,
+	keys = {
+		{ '<leader>cro', ':ColorizerToggle<CR>', noremap }, -- toggle colorizer
+	},
+}

--- a/lua/plugins/vim-markdown-toc.lua
+++ b/lua/plugins/vim-markdown-toc.lua
@@ -1,0 +1,14 @@
+-- https://github.com/mzlogin/vim-markdown-toc
+
+local noremap = { noremap = true, silent = true }
+
+return {
+	'mzlogin/vim-markdown-toc',
+	lazy = true,
+	ft = { 'markdown' },
+	keys = {
+		{ '<leader>mco', ':GenTocGFM<CR>', noremap }, -- generate markdown table of contents
+		{ '<leader>mcu', ':UpdateToc<CR>', noremap }, -- update markdown table of contents
+		{ '<leader>mcd', ':RemoveToc<CR>', noremap }, -- delete markdown table of contents
+	},
+}


### PR DESCRIPTION
Create dedicated files for `vim-markdown-toc`, `vim-table-mode`, and `harpoon` plugins, ensuring associated keymaps reside within their respective plugin files, streamlining organization and readability.