### PR TITLE
refactor: Remap keymaps for toggle-term

### DIFF
--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -75,7 +75,6 @@ keymap.set('n', '<leader>hio', ':so $VIMRUNTIME/syntax/hitest.vim<CR>', noremap)
 keymap.set('n', '<ESC>', ':noh<CR>', noremap) -- exit search highlight
 
 -- typescript
--- More Info: https://github.com/pmizio/typescript-tools.nvim/blob/master/lua/typescript-tools/user_commands.lua
 keymap.set('n', '<leader>fr', '<cmd>TypescriptRenameFile<CR>', noremap) -- rename file and update imports                                   █│
 keymap.set('n', '<leader>fd', '<cmd>TypescriptRemoveUnused<CR>', noremap) -- remove unused variables                                        █│
 keymap.set('n', '<leader>fm', '<cmd>TypescriptAddMissingImports<CR>', noremap) -- add missing imports                                       █│

--- a/lua/plugins/toggle-term.lua
+++ b/lua/plugins/toggle-term.lua
@@ -2,8 +2,8 @@ return {
 	'akinsho/toggleterm.nvim',
 	version = '*',
 	keys = {
-		{ '<leader>tt', ':ToggleTerm<CR>', { noremap = true, silent = true } },
-		{ '<leader>tl', ':lua_LAZYGIT_TOGGLE()<CR>', { noremap = true, silent = true } },
+		{ '<leader>at', ':ToggleTerm<CR>', { noremap = true, silent = true } },
+		{ '<leader>al', ':lua_LAZYGIT_TOGGLE()<CR>', { noremap = true, silent = true } },
 	},
 	config = function()
 		require('toggleterm').setup({


### PR DESCRIPTION
toggleTerm's keymaps now start with `a` instead of `t`. Superfluous comments within the global `keymap` have been removed.