### PR TITLE
feat: Add the new workflow to cleanup workflow runs (#333)

### DIFF
--- a/.github/workflows/cleanup-workflow-runs.yml
+++ b/.github/workflows/cleanup-workflow-runs.yml
@@ -1,0 +1,21 @@
+name: Cleanup Workflow Runs
+
+on:
+  schedule:
+    - cron: "0 0 */30 * *" # every 30 days at midnight (UTC)
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          retain_days: 20
+          keep_minimum_runs: 6


### PR DESCRIPTION
The current update of workflow will run cron job every 90 days to only retain 20 days of workflow runs.