### PR TITLE
refactor: Modify gitcommit colorcolumn setting

### DIFF
--- a/lua/autocmd.lua
+++ b/lua/autocmd.lua
@@ -6,7 +6,7 @@ vim.cmd([[
     autocmd!
     " autocmd BufRead,BufNewFile * if &filetype != 'markdown' && &filetype != 'gitcommit' | set textwidth=0 nowrap colorcolumn=80 | endif
     autocmd FileType markdown set textwidth=80 wrap colorcolumn=80,90
-    autocmd FileType gitcommit set colorcolumn=63,80
+    autocmd FileType gitcommit set colorcolumn=50,80
   augroup end
 ]])
 


### PR DESCRIPTION
Adjust the colorcolumn setting for gitcommit within autocmd to 50, enhancing visual guidelines for commit message length.