### PR TITLE
feat: Add the two new autocmds

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -2,7 +2,6 @@
   "Comment.nvim": { "branch": "master", "commit": "0236521ea582747b58869cb72f70ccfa967d2e89" },
   "LuaSnip": { "branch": "master", "commit": "c4d6298347f7707e9757351b2ee03d0c00da5c20" },
   "ReplaceWithRegister": { "branch": "master", "commit": "832efc23111d19591d495dc72286de2fb0b09345" },
-  "auto-session": { "branch": "main", "commit": "f6d111f3c7ff2fb89c8a39b6280c8f90234196d9" },
   "barbecue": { "branch": "main", "commit": "cd7e7da622d68136e13721865b4d919efd6325ed" },
   "browser-bookmarks.nvim": { "branch": "main", "commit": "e643372d509d138d3244f917283b13f52a9cf5eb" },
   "cmp-buffer": { "branch": "main", "commit": "3022dbc9166796b644a841a02de8dd1cc1d311fa" },

--- a/lua/autocmd.lua
+++ b/lua/autocmd.lua
@@ -58,3 +58,23 @@ vim.cmd([[
 ----------------------------------
 vim.cmd([[autocmd BufUnload * :let @/ = ""]])
 
+--------------------------------------------------
+-- Register buffer to Harpoon before leave nvim --
+--------------------------------------------------
+vim.cmd([[
+  augroup AutoHarpoonMark
+    autocmd!
+    function! AddFileToHarpoon()
+      if getline(1, '$') != ['']
+        " lua require("harpoon.mark").clear_all() 
+        lua require("harpoon.mark").add_file()
+      endif
+    endfunction
+    autocmd VimLeavePre * call AddFileToHarpoon()
+  augroup end
+]])
+
+-----------------------------------
+-- Clear Jump when Enter the Vim --
+-----------------------------------
+vim.cmd([[autocmd VimEnter * :clearjumps]])


### PR DESCRIPTION
Add an autocmd to register the buffer into Harpoon before leaving Neovim, with a conditional check to avoid execution when leaving an empty buffer. Additionally, add an autocmd to clear jump history when entering Neovim, preventing unwanted jumping.