### PR TITLE
feat: Enhance auto register condition for Harpoon

### DIFF
--- a/lua/autocmd.lua
+++ b/lua/autocmd.lua
@@ -65,8 +65,8 @@ vim.cmd([[
   augroup AutoHarpoonMark
     autocmd!
     function! AddFileToHarpoon()
-      if getline(1, '$') != ['']
-        " lua require("harpoon.mark").clear_all() 
+      if getline(1, '$') != [''] && expand('%:p') !~ '/\.git/' && &filetype != 'gitcommit'
+        " lua require("harpoon.mark").clear_all()
         lua require("harpoon.mark").add_file()
       endif
     endfunction


### PR DESCRIPTION
Modify the auto register function with autocmd to bypass files that match with .git and filetype gitcommit, ensuring specific file handling in the codebase.