### PR TITLE
feat: Install and update telescope-file-extension

### DIFF
--- a/lua/plugins/telescope/init.lua
+++ b/lua/plugins/telescope/init.lua
@@ -8,11 +8,13 @@ return {
 	dependencies = {
 		'nvim-telescope/telescope-fzf-native.nvim',
 		'dhruvmanila/browser-bookmarks.nvim',
+		'nvim-telescope/telescope-file-browser.nvim',
 		build = 'make',
 	},
 	keys = keymaps,
 	config = function()
 		local default_configs = require('plugins.telescope.configs')
+		local fb_actions = require('telescope._extensions.file_browser.actions')
 
 		require('telescope').setup({
 			defaults = default_configs,
@@ -21,11 +23,33 @@ return {
 					-- theme = "dropdown",
 				},
 			},
-			extensions = { bookmarks = {
-				selected_browser = 'chrome',
-			} },
+			extensions = {
+				bookmarks = {
+					selected_browser = 'chrome',
+				},
+				file_browser = {
+					hijack_netrw = true,
+					grouped = true,
+					hidden = { file_browser = false, folder_browser = false },
+					display_stat = { date = true, size = true },
+					mappings = {
+						['i'] = {
+							['<End>'] = fb_actions.goto_cwd,
+							['<Home>'] = fb_actions.goto_parent_dir,
+							['<S-c>'] = fb_actions.create,
+							['<S-d>'] = fb_actions.remove,
+							['<S-r>'] = fb_actions.rename,
+							['<S-m>'] = fb_actions.move,
+							['<S-y>'] = fb_actions.copy,
+							['<S-h>'] = fb_actions.toggle_hidden,
+							['<S-o>'] = fb_actions.toggle_all,
+						},
+					},
+				},
+			},
 		})
 		require('telescope').load_extension('fzf')
 		require('telescope').load_extension('bookmarks')
+		require('telescope').load_extension('file_browser')
 	end,
 }

--- a/lua/plugins/telescope/keymaps.lua
+++ b/lua/plugins/telescope/keymaps.lua
@@ -16,4 +16,7 @@ return {
 	{ '<leader>st', ':TodoTelescope keywords=TODO,HACK,NOTE,WARN,PERF,TEST,FIX,FIXME,FIXIT,BUG,ISSUE<CR>', noremap }, -- open todo-comments within telescope
 	-- telescope bookmarks
 	{ '<leader>sbo', '<cmd>Telescope bookmarks<CR>', noremap }, -- open bookmarks
+	-- telescope file browser
+	{ '<leader>eo', '<cmd>Telescope file_browser previewer=false<CR>', noremap }, -- open file browser
+	{ '<leader>ef', '<cmd>Telescope file_browser path=%:p:h select_buffer=true previewer=false<CR>', noremap }, -- open file browser with the current buffer
 }


### PR DESCRIPTION
Add the telescope-file-extension as the replacement of the oil.nvim and update its configs.