### PR TITLE
feat: Reinstall archived Typescript.nvim plugin

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -12,7 +12,6 @@
   "gitsigns.nvim": { "branch": "main", "commit": "5a9a6ac29a7805c4783cda21b80a1e361964b3f2" },
   "harpoon": { "branch": "master", "commit": "c1aebbad9e3d13f20bedb8f2ce8b3a94e39e424a" },
   "indent-blankline.nvim": { "branch": "master", "commit": "046e2cf04e08ece927bacbfb87c5b35c0b636546" },
-  "iron.nvim": { "branch": "master", "commit": "7f876ee3e1f4ea1e5284b1b697cdad5b256e8046" },
   "kanagawa.nvim": { "branch": "master", "commit": "c19b9023842697ec92caf72cd3599f7dd7be4456" },
   "lazy.nvim": { "branch": "main", "commit": "e42fccc3cda70266e0841c5126de2c23e8982800" },
   "lspsaga.nvim": { "branch": "main", "commit": "199eb00822f65b811f43736ba65ab7e16501125d" },
@@ -38,6 +37,7 @@
   "todo-comments.nvim": { "branch": "main", "commit": "3094ead8edfa9040de2421deddec55d3762f64d1" },
   "toggleterm.nvim": { "branch": "main", "commit": "faee9d60428afc7857e0927fdc18daa6c409fa64" },
   "tw-values.nvim": { "branch": "main", "commit": "3808621a53f6ac9c151b77d9df61b29991c12921" },
+  "typescript.nvim": { "branch": "main", "commit": "4de85ef699d7e6010528dcfbddc2ed4c2c421467" },
   "vim-markdown-toc": { "branch": "master", "commit": "7ec05df27b4922830ace2246de36ac7e53bea1db" },
   "vim-matchup": { "branch": "master", "commit": "6dbe108230c7dbbf00555b7d4d9f6a891837ef07" },
   "vim-table-mode": { "branch": "master", "commit": "9ac358083943f6339fc304a6e218b634fd1e30bd" }

--- a/lua/plugins/lspconfig/servers.lua
+++ b/lua/plugins/lspconfig/servers.lua
@@ -18,14 +18,14 @@ M.html = {
 	},
 }
 
-local function organize_imports()
-	local params = {
-		command = '_typescript.organizeImports',
-		arguments = { vim.api.nvim_buf_get_name(0) },
-		title = '',
-	}
-	vim.lsp.buf.execute_command(params)
-end
+-- local function organize_imports()
+-- 	local params = {
+-- 		command = '_typescript.organizeImports',
+-- 		arguments = { vim.api.nvim_buf_get_name(0) },
+-- 		title = '',
+-- 	}
+-- 	vim.lsp.buf.execute_command(params)
+-- end
 
 M.tsserver = {
 	capabilities = capabilities,
@@ -35,12 +35,12 @@ M.tsserver = {
 		publish_diagnostic_on = 'change',
 		tsserver_max_memory = 'auto',
 	},
-	commands = {
-		OrganizeImports = {
-			organize_imports,
-			description = 'Organize Imports',
-		},
-	},
+	-- commands = {
+	-- 	OrganizeImports = {
+	-- 		organize_imports,
+	-- 		description = 'Organize Imports',
+	-- 	},
+	-- },
 	handlers = {
 		['textDocument/publishDiagnostics'] = function(_, result, ctx, ...)
 			local client = vim.lsp.get_client_by_id(ctx.client_id)

--- a/lua/plugins/typescript_nvim/init.lua
+++ b/lua/plugins/typescript_nvim/init.lua
@@ -1,0 +1,37 @@
+local noremap = { noremap = true, silent = true }
+
+-- vim.lsp.handlers['textDocument/publishDiagnostics'] = function(_, result, ctx, ...)
+-- 	local client = vim.lsp.get_client_by_id(ctx.client_id)
+--
+-- 	if client and client.name == 'tsserver' then
+-- 		result.diagnostics = vim.tbl_filter(function(diagnostic)
+-- 			return not diagnostic.message:find('File is a CommonJS module; it may be converted to an ES module.')
+-- 		end, result.diagnostics)
+-- 	end
+--
+-- 	return vim.lsp.diagnostic.on_publish_diagnostics(nil, result, ctx, ...)
+-- end
+
+return {
+	'jose-elias-alvarez/typescript.nvim',
+	event = 'BufReadPre',
+	dependencies = { 'nvim-lua/plenary.nvim', 'neovim/nvim-lspconfig' },
+	keys = {
+		{ '<leader>fr', '<cmd>TypescriptRenameFile<CR>', noremap }, -- rename file and update imports
+		{ '<leader>fd', '<cmd>TypescriptRemoveUnused<CR>', noremap }, -- remove unused variables
+		{ '<leader>fm', '<cmd>TypescriptAddMissingImports<CR>', noremap }, -- add missing imports
+		{ '<leader>fo', '<cmd>TypescriptOrganizeImports<CR>', noremap }, -- Organize Import (Custom: typescript)
+	},
+	config = function()
+		local capabilities = require('cmp_nvim_lsp').default_capabilities()
+
+		require('typescript').setup({
+			capabilities = capabilities,
+			settings = {
+				separate_diagnostic_server = true,
+				publish_diagnostic_on = 'insert_leave',
+				tsserver_max_memory = 'auto',
+			},
+		})
+	end,
+}


### PR DESCRIPTION
Reinstalled archived Typescript.nvim plugin due to its unique support for global diagnostics. While Typescript-tools serves as an alternative, it lacks current support for this feature. Typescript.nvim to act as interim solution until workspace diagnostics receive proper support.