### PR TITLE
feat: Add the custom harpoon autocmd

### DIFF
--- a/lua/plugins/harpoon/autocmd.lua
+++ b/lua/plugins/harpoon/autocmd.lua
@@ -1,0 +1,28 @@
+----------------------------------
+-- Add Harpoon before leave vim --
+----------------------------------
+vim.cmd([[
+  let s:excluded_filetypes = ['oil', 'gitcommit']
+  let s:excluded_filenames = ['wezterm.lua']
+
+  augroup AutoAddHarpoon
+    function! AddToHarpoon()
+      for filetype in s:excluded_filetypes
+        if &filetype == filetype
+          return
+        endif
+      endfor
+
+      let filename = expand('%:t') 
+      for excluded_filename in s:excluded_filenames
+        if filename == excluded_filename
+          return
+        endif
+      endfor
+
+      lua require('harpoon.mark').add_file()
+    endfunction
+    autocmd!
+    autocmd VimLeave * call AddToHarpoon()
+  augroup end
+]])

--- a/lua/plugins/harpoon/init.lua
+++ b/lua/plugins/harpoon/init.lua
@@ -1,5 +1,6 @@
 -- https://github.com/ThePrimeagen/harpoon
 
+require('plugins.harpoon.autocmd')
 local noremap = { noremap = true, silent = true }
 
 return {


### PR DESCRIPTION
Add the custom autocmd for harpoon to add the buffer to harpoon before leaving the Vim. This enables the possbility to replace the autosession related plugin.