### PR TITLE
feat: Remove autocmd to autostart TSC

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -19,7 +19,6 @@
   "lualine.nvim": { "branch": "master", "commit": "2248ef254d0a1488a72041cfb45ca9caada6d994" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "41674c9d50f23cfa3e11f0ca964eb9100c2a8922" },
   "mason.nvim": { "branch": "main", "commit": "41e75af1f578e55ba050c863587cffde3556ffa6" },
-  "none-ls.nvim": { "branch": "main", "commit": "fc0f6013ced00fbd61a1ee079427ad445eea0e4b" },
   "nvim-autopairs": { "branch": "master", "commit": "0f04d78619cce9a5af4f355968040f7d675854a1" },
   "nvim-cmp": { "branch": "main", "commit": "0b751f6beef40fd47375eaf53d3057e0bfa317e4" },
   "nvim-colorizer.lua": { "branch": "master", "commit": "36c610a9717cc9ec426a07c8e6bf3b3abcb139d6" },

--- a/lua/plugins/tsc/init.lua
+++ b/lua/plugins/tsc/init.lua
@@ -35,15 +35,5 @@ return {
 			hide_progress_notifications_from_history = true,
 			spinner = { '⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷' },
 		})
-
-		vim.api.nvim_create_autocmd('FileType', {
-			pattern = { 'typescript', 'typescriptreact' },
-			callback = function()
-				if vim.b.did_run_tsc == nil then
-					vim.cmd(':TSC')
-					vim.b.did_run_tsc = true
-				end
-			end,
-		})
 	end,
 }


### PR DESCRIPTION
There is a conflict between watch mode and autocmd. Currently autocmd has been removed.